### PR TITLE
Fix example registration of Twig Service Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ session_start();
 
 $app = new \Slim\App();
 
+// Fetch DI Container
+$container = $app->getContainer();
+
 // Register provider
-$app->register(new \Slim\Flash\Messages);
+$container->register(new \Slim\Flash\Messages);
 
 $app->get('/foo', function ($req, $res, $args) {
     // Set flash message for next request


### PR DESCRIPTION
\Slim\App is no longer a instance of \Pimple\Container. This affects registration of Pimple Service Providers. See issue https://github.com/slimphp/Slim/issues/1250.
