### PR TITLE
flash messages for current request

### DIFF
--- a/src/Messages.php
+++ b/src/Messages.php
@@ -18,6 +18,13 @@ class Messages
     protected $fromPrevious = [];
 
     /**
+     * Messages for current request
+     *
+     * @var string[]
+     */
+    protected $forNow = [];
+
+    /**
      * Messages for next request
      *
      * @var string[]
@@ -67,7 +74,7 @@ class Messages
     }
 
     /**
-     * Add flash message
+     * Add flash message for the next request
      *
      * @param string $key The key to store the message under
      * @param mixed  $message Message to show on next request
@@ -84,13 +91,42 @@ class Messages
     }
 
     /**
+     * Add flash message for current request
+     *
+     * @param string $key The key to store the message under
+     * @param mixed  $message Message to show on next request
+     */
+    public function addMessageNow($key, $message){
+
+        //Create Array for this key
+        if(!isset($this->forNow[$key])){
+            $this->forNow[$key] = array();
+        }
+
+        //Push onto the array
+        $this->forNow[$key][] = $message;
+    }
+
+    /**
      * Get flash messages
      *
      * @return array Messages to show for current request
      */
     public function getMessages()
     {
-        return $this->fromPrevious;
+        $messages = $this->fromPrevious;
+
+        foreach($this->forNow as $key => $values){
+            if(!isset($messages[$key])){
+                $messages[$key] = array();
+            }
+
+            foreach($values as $value){
+                array_push($messages[$key], $value);
+            }
+        }
+
+        return $messages;
     }
 
     /**
@@ -101,7 +137,8 @@ class Messages
      */
     public function getMessage($key)
     {
+        $messages = $this->getMessages();
         //If the key exists then return all messages or null
-        return (isset($this->fromPrevious[$key])) ? $this->fromPrevious[$key] : null;
+        return (isset($messages[$key])) ? $messages[$key] : null;
     }
 }

--- a/tests/MessagesTest.php
+++ b/tests/MessagesTest.php
@@ -16,6 +16,76 @@ class MessagesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['Test'], $flash->getMessages());
     }
 
+    // Test a string can be added to a message array for the current request
+    public function testAddMessageFromAnIntegerForCurrentRequest()
+    {
+        $storage = ['slimFlash' => []];
+        $flash   = new Messages($storage);
+
+        $flash->addMessageNow('key', 46);
+        $flash->addMessageNow('key', 48);
+
+        $messages = $flash->getMessages();
+        $this->assertEquals(['46','48'], $messages['key']);
+
+        $this->assertArrayHasKey('slimFlash', $storage);
+        $this->assertEmpty($storage['slimFlash']);
+    }
+
+    // Test a string can be added to a message array for the current request
+    public function testAddMessageFromStringForCurrentRequest()
+    {
+        $storage = ['slimFlash' => []];
+        $flash   = new Messages($storage);
+
+        $flash->addMessageNow('key', 'value');
+
+        $messages = $flash->getMessages();
+        $this->assertEquals(['value'], $messages['key']);
+
+        $this->assertArrayHasKey('slimFlash', $storage);
+        $this->assertEmpty($storage['slimFlash']);
+    }
+
+    // Test an array can be added to a message array for the current request
+    public function testAddMessageFromArrayForCurrentRequest()
+    {
+        $storage = ['slimFlash' => []];
+        $flash   = new Messages($storage);
+
+        $formData = [
+            'username'     => 'Scooby Doo',
+            'emailAddress' => 'scooby@mysteryinc.org',
+        ];
+
+        $flash->addMessageNow('old', $formData);
+
+        $messages = $flash->getMessages();
+        $this->assertEquals($formData, $messages['old'][0]);
+
+        $this->assertArrayHasKey('slimFlash', $storage);
+        $this->assertEmpty($storage['slimFlash']);
+    }
+
+    // Test an object can be added to a message array for the current request
+    public function testAddMessageFromObjectForCurrentRequest()
+    {
+        $storage = ['slimFlash' => []];
+        $flash   = new Messages($storage);
+
+        $user = new \stdClass();
+        $user->name         = 'Scooby Doo';
+        $user->emailAddress = 'scooby@mysteryinc.org';
+
+        $flash->addMessageNow('user', $user);
+
+        $messages = $flash->getMessages();
+        $this->assertInstanceOf(\stdClass::class, $messages['user'][0]);
+
+        $this->assertArrayHasKey('slimFlash', $storage);
+        $this->assertEmpty($storage['slimFlash']);
+    }
+
     // Test a string can be added to a message array for the next request
     public function testAddMessageFromAnIntegerForNextRequest()
     {
@@ -83,6 +153,25 @@ class MessagesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([], $flash->getMessages());
     }
 
+    // Test set messages for current request
+    public function testSetMessagesForCurrentRequest()
+    {
+        $storage = ['slimFlash' => [ 'error' => ['An error']]];
+
+        $flash = new Messages($storage);
+        $flash->addMessageNow('error', 'Another error');
+        $flash->addMessageNow('success', 'A success');
+        $flash->addMessageNow('info', 'An info');
+
+        $messages = $flash->getMessages();
+        $this->assertEquals(['An error', 'Another error'], $messages['error']);
+        $this->assertEquals(['A success'], $messages['success']);
+        $this->assertEquals(['An info'], $messages['info']);
+
+        $this->assertArrayHasKey('slimFlash', $storage);
+        $this->assertEmpty([], $storage['slimFlash']);
+    }
+
     // Test set messages for next request
     public function testSetMessagesForNextRequest()
     {
@@ -103,5 +192,17 @@ class MessagesTest extends \PHPUnit_Framework_TestCase
         $flash = new Messages($storage);
 
         $this->assertEquals(['Test', 'Test2'], $flash->getMessage('Test'));        
+    }
+
+    //Test getting the message from the key
+    public function testGetMessageFromKeyIncludingCurrent()
+    {
+        $storage = ['slimFlash' => [ 'Test' => ['Test', 'Test2']]];
+        $flash = new Messages($storage);
+        $flash->addMessageNow('Test', 'Test3');
+
+        $messages = $flash->getMessages();
+
+        $this->assertEquals(['Test', 'Test2','Test3'], $flash->getMessage('Test'));
     }
 }


### PR DESCRIPTION
Hi,

I've added the ability to show flash for current request. So you call `addMessageNow()` if you want to show a message in the current request or `addMessage()` if you want to show a message in the next request.

``` php
$flash->addMessageNow('error', 'Something went wrong');
// contains messages from previous and current request
$messages = $flash->getMessages();
```
